### PR TITLE
Update `POSTFIXPATH_SDKROOT` for new OS X versions

### DIFF
--- a/aseprite.sh
+++ b/aseprite.sh
@@ -3,7 +3,7 @@
 # Script to automate building latest release of Aseprite (it can be release or beta build)
 # This is for macOS build version.
 
-POSTFIXPATH_SDKROOT=Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk
+POSTFIXPATH_SDKROOT=Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
 CCPATH_TOOLCHAIN=Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
 CXXPATH_TOOLCHAIN=Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
 SDK_ROOT=`xcode-select -p`


### PR DESCRIPTION
On my machine, `MacOSX.11.3.sdk` does not exist (which causes the build to fail), but `MacOSX.12.1.sdk` does, which is just a symlink to `MacOSX.sdk` anyway, so pointing to `MacOSX.sdk` seems more future-proof.

Fixes #12 